### PR TITLE
Added dbl-quote escaping for node text

### DIFF
--- a/Export OPML from selected node.groovy
+++ b/Export OPML from selected node.groovy
@@ -25,7 +25,7 @@ class OPMLWriter {
     def outline_tag='<outline $$attributes$$>'
     def processNode(newNode, childPosition) {
         def nodeLevel = newNode.getNodeLevel(true)
-        def outline_attribs='text="'+newNode.plainText+'"'
+        def outline_attribs='text="'+convertQuotes(newNode.plainText)+'"'
         def hasnote=false
         if (newNode.noteText) {
             outline_attribs+=' _note="'+removeHtmlTags(newNode.noteText)+'"'
@@ -61,6 +61,12 @@ class OPMLWriter {
         strippedText = strippedText.replaceAll('<.*?>', '') // remove anythiing in between < and >
         strippedText = strippedText.replaceAll('^\\s*', '') // remove whitespace
         strippedText = strippedText.replaceAll('\n\n\n','\n') // replace multiple line feed with single line feed
+        strippedText = strippedText.replaceAll('\"','&quot;') // replace double quotes with XML escaped version
+        return strippedText
+    }
+
+    def convertQuotes(text) {
+        def strippedText = text.replaceAll('\"','&quot;') // replace double quotes with XML escaped version
         return strippedText
     }
 
@@ -121,4 +127,3 @@ if (returnVal == JFileChooser.APPROVE_OPTION) {
 } else {
     c.statusInfo="Export OPML cancelled by user"
 }
-


### PR DESCRIPTION
Hi!  Thanks for your groovy script.  I'm not that great in Groovy but I'm OK in doing QA (if it's for my own benefit ;-).  Found a bug in that double quotes in node text breaks the generated OPML.  I put in a relatively clean enhancement.  Thoughts?  Is it groovy-thonic enough?